### PR TITLE
http_cache, configable template location, composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/Controller/StaticPageController.php
+++ b/Controller/StaticPageController.php
@@ -28,7 +28,9 @@ class StaticPageController extends Controller
             return $this->redirect('/', 301);
         }
 
-        $template = sprintf('JPetitcolasStaticPageBundle:StaticPage:%s.html.twig', $page);
+        //make Location configable
+        $location = $this->container->getParameter('j_petitcolas_static_page.template.location');
+        $template = sprintf($location, $page);
         if(!$this->get('templating')->exists($template)) {
             throw new NotFoundHttpException(sprintf('Unable to find template %s.', $template));
         }

--- a/Controller/StaticPageController.php
+++ b/Controller/StaticPageController.php
@@ -34,7 +34,19 @@ class StaticPageController extends Controller
         if(!$this->get('templating')->exists($template)) {
             throw new NotFoundHttpException(sprintf('Unable to find template %s.', $template));
         }
-
-        return $this->render($template);
+        
+        $response = $this->render($template);
+        if($this->container->getParameter('j_petitcolas_static_page.httpcache')){
+            if($this->container->getParameter('j_petitcolas_static_page.httpcache.Public')){
+                $response->setPublic();
+            }
+            else{
+                $response->setPrivate();
+            }
+            $response->setMaxAge($this->container->getParameter('j_petitcolas_static_page.httpcache.MaxAge'));
+            $response->setSharedMaxAge($this->container->getParameter('j_petitcolas_static_page.httpcache.SharedMaxAge'));
+            $response->setTtl($this->container->getParameter('j_petitcolas_static_page.httpcache.TTL'));
+        }
+        return $response;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,15 @@
     
     <parameters>
         <!--<parameter key="j_petitcolas_static_page.example.class">JPetitcolas\StaticPageBundle\Example</parameter>-->
+        <parameter key="j_petitcolas_static_page.httpcache">true</parameter>
+        <!--Whether or not caching should apply for client caches only-->
+        <parameter key="j_petitcolas_static_page.httpcache.Public">true</parameter>
+        <!--Default max age time in seconds for client (browser) caching-->
+        <parameter key="j_petitcolas_static_page.httpcache.MaxAge">86400</parameter>
+        <!--Default max age time in seconds for shared (proxy) caching-->
+        <parameter key="j_petitcolas_static_page.httpcache.SharedMaxAge">86400</parameter>
+        <!--Default TTL-->
+        <parameter key="j_petitcolas_static_page.httpcache.TTL">86400</parameter>
         <parameter key="j_petitcolas_static_page.template.location">JPetitcolasStaticPageBundle:StaticPage:%s.html.twig</parameter>
     </parameters>
     <!--

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,11 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <!--
+    
     <parameters>
-        <parameter key="j_petitcolas_static_page.example.class">JPetitcolas\StaticPageBundle\Example</parameter>
+        <!--<parameter key="j_petitcolas_static_page.example.class">JPetitcolas\StaticPageBundle\Example</parameter>-->
+        <parameter key="j_petitcolas_static_page.template.location">JPetitcolasStaticPageBundle:StaticPage:%s.html.twig</parameter>
     </parameters>
-
+    <!--
     <services>
         <service id="j_petitcolas_static_page.example" class="%j_petitcolas_static_page.example.class%">
             <argument type="service" id="service_id" />

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "jpetitcolas/static-page-bundle",
+    "type": "symfony-bundle",
+    "description": "Easy serving of Static Pages with Symfony using Twig Templates",
+    "keywords": ["static", "content", "page", "bundle"],
+    "authors": 
+    [
+    ],
+    "require": 
+    {
+        "php": ">=5.3.0",
+        "symfony/framework-bundle": ">=2.0.0"
+    },
+    "autoload": 
+    {
+        "psr-0": 
+        {
+            "JPetitcolas\\StaticPageBundle": ""
+        }
+    },
+    "target-dir": "JPetitcolas/StaticPageBundle"
+}


### PR DESCRIPTION
Inspired by http://symfony.com/blog/new-in-symfony-2-2-cache-support-for-static-pages
and because i needed to have the template location cinfigurable , i made some improvements to the bundle.
i guess the bundle is still useful, because there is no need for a route for each page, and for bc

changes:
- composer.json
- template location configurable
- http_cache support, configurable
